### PR TITLE
remove html tags from plain text

### DIFF
--- a/_themes/statarkers/templates/emails/reset_password_text.html
+++ b/_themes/statarkers/templates/emails/reset_password_text.html
@@ -1,1 +1,1 @@
-Plain text email, <a href="{{ reset_url }}">reset Password</a>.
+Plain text email, click here to reset password: {{ reset_url }}.


### PR DESCRIPTION
Statamic throws TRIGGER error when the plain text file has html tags in it.....